### PR TITLE
mark `action` proc as `gcsafe`

### DIFF
--- a/threadpool_simple.nim
+++ b/threadpool_simple.nim
@@ -19,7 +19,7 @@ type
             v: T
 
     MsgTo = object
-        action: proc(flowVar: pointer, chanFrom: ChannelFromPtr)
+        action: proc(flowVar: pointer, chanFrom: ChannelFromPtr) {.gcsafe.}
         flowVar: pointer
         complete: bool
 


### PR DESCRIPTION
After updating the compiler I was greeted with
```
~/src/nim/threadpools/threadpool_simple.nim(68, 10) Error: 'threadProc' is not GC-safe as it performs an indirect call here 
```

I hope marking the `action` proc as `gcsafe` is all that's really needed. My code works fine at least.